### PR TITLE
Enable persistence

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,11 @@
                     package = postgres;
                     settings.port = projectConfig.port;
                   };
+
+                  garnix.server.persistence = {
+                    enable = true;
+                    name = "postgresql";
+                  };
                 })
                 config.postgresql);
           };


### PR DESCRIPTION
Tested locally using testing.garnix.io.
I created a empty repository (with one commit). I enabled the repository in the garnix testing app configuration.
I inserted the module schema in the local database using `nix run .\#backend-readModuleSchema /home/jfroche/projects/garnix/postgresql-module`.
In testing.garnix.io I could then select that repo in module configuration page, enabled postgresql and managed to start a build using the module run. 
I managed to download the flake locally as well and ran a `nix flake show` and build the nixosConfiguration using `nix build -L .#nixosConfigurations.default.config.system.build.toplevel`.

Also created a postgresql template here: https://github.com/garnix-io/postgresql-template