### PR TITLE
Remove nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,6 @@
 {
   "nodes": {
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1734737257,
-        "narHash": "sha256-GIMyMt1pkkoXdCq9un859bX6YQZ/iYtukb9R5luazLM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1c6e20d41d6a9c1d737945962160e8571df55daa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "root": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      }
-    }
+    "root": {}
   },
   "root": "root",
   "version": 7

--- a/flake.nix
+++ b/flake.nix
@@ -7,42 +7,49 @@
     [Documentation](https://garnix.io/docs/modules/postgresql) - [Source](https://github.com/garnix-io/postgresql-module).
   '';
 
-  outputs = { self }: {
-    garnixModules.default = { pkgs, lib, config, ... }:
-    let
-      postgresqlSubmodule.options = {
-        port = lib.mkOption {
-          type = lib.types.port;
-          description = "The port on which to run PostgreSQL.";
-          default = 5432;
-        };
-
-      };
-    in
+  outputs =
+    { self }:
     {
-        options = {
-          postgresql = lib.mkOption {
-            type = lib.types.attrsOf (lib.types.submodule postgresqlSubmodule);
-            description = "An attrset of PostgreSQL databases.";
+      garnixModules.default =
+        {
+          pkgs,
+          lib,
+          config,
+          ...
+        }:
+        let
+          postgresqlSubmodule.options = {
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = "The port on which to run PostgreSQL.";
+              default = 5432;
+            };
+
           };
-        };
+        in
+        {
+          options = {
+            postgresql = lib.mkOption {
+              type = lib.types.attrsOf (lib.types.submodule postgresqlSubmodule);
+              description = "An attrset of PostgreSQL databases.";
+            };
+          };
 
-        config =
-          let postgres = pkgs.postgresql_17;
-          in {
+          config =
+            let
+              postgres = pkgs.postgresql_17;
+            in
+            {
 
-            devShells = builtins.mapAttrs
-              (name: projectConfig:
+              devShells = builtins.mapAttrs (
+                name: projectConfig:
                 pkgs.mkShell {
                   packages = [ postgres ];
                 }
-              )
-              config.postgresql;
+              ) config.postgresql;
 
-
-            nixosConfigurations.default =
-              builtins.attrValues (builtins.mapAttrs
-                (name: projectConfig: {
+              nixosConfigurations.default = builtins.attrValues (
+                builtins.mapAttrs (name: projectConfig: {
                   environment.systemPackages = [ postgres ];
 
                   services.postgresql = {
@@ -55,9 +62,9 @@
                     enable = true;
                     name = "postgresql";
                   };
-                })
-                config.postgresql);
-          };
-      };
+                }) config.postgresql
+              );
+            };
+        };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,16 +7,9 @@
     [Documentation](https://garnix.io/docs/modules/postgresql) - [Source](https://github.com/garnix-io/postgresql-module).
   '';
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
-
-  outputs =
-    { self
-    , nixpkgs
-    ,
-    }:
+  outputs = { self }: {
+    garnixModules.default = { pkgs, lib, config, ... }:
     let
-      lib = nixpkgs.lib;
-
       postgresqlSubmodule.options = {
         port = lib.mkOption {
           type = lib.types.port;
@@ -27,7 +20,6 @@
       };
     in
     {
-      garnixModules.default = { pkgs, config, ... }: {
         options = {
           postgresql = lib.mkOption {
             type = lib.types.attrsOf (lib.types.submodule postgresqlSubmodule);
@@ -69,4 +61,3 @@
       };
     };
 }
-


### PR DESCRIPTION
The `nixpkgs` dependency was only being used for library functions, and
these functions are only needed within `garnixModules.default` which
receives `lib` from `garnix-lib`. By removing the `nixpkgs` input we can
be assured that there is only one `nixpkgs` being used: the one passed
in from `garnix-lib`.